### PR TITLE
fix vega-load/vega-canvas file missing compilation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "react-dom": "^16.5.2",
     "vega": "^5.3.5",
     "vega-embed": "^4.0.0",
-    "vega-lite": "^3.2.1"
+    "vega-lite": "^3.2.1",
+    "vega-loader": "4.3.2",
+    "vega-canvas": "1.2.4"
   },
   "devDependencies": {
     "shadow-cljs": "^2.6.10"


### PR DESCRIPTION
I couldn't get this project to compile as is and ran into the error described in https://github.com/metasoarous/oz/issues/64#issuecomment-698343242

With some assistance from Thomas Heller, I figured out that two of vega's dependencies, vega-loader and vega-canvas, have been packaged wrong in their latest incarnations (4.3.3 and 1.2.5, respectively). As a workaround, I have added explicit dependencies for the previous versions of both to `package.json`. It now compiles on my machine.